### PR TITLE
Update requirements.txt to mlconjug3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 nltk
-mlconjug
+mlconjug3


### PR DESCRIPTION
Hi @matthew-cheney.

I am the author of mlconjug and I wanted to let you know that mlconjug is now mlconjug3 as I wanted to make explicit that mlconjug3 no longer supports python 2.x as it has been deprecated.

I made this pull request to update your dependency to mlconjug3 as there has been enhancements such as better accuracy in conjugating unknown verbs and many bug fixes.

Cheers,

SekouDiaoNLP.